### PR TITLE
Add hasBeenValidated to FieldState

### DIFF
--- a/src/core/fieldState.ts
+++ b/src/core/fieldState.ts
@@ -56,6 +56,7 @@ export class FieldState<TValue> implements ComposibleValidatable<TValue> {
   }
 
   /** Trackers for validation */
+  @observable public hasBeenValidated: boolean = false;
   @observable private lastValidationRequest: number = 0;
   @observable private preventNextQueuedValidation = false;
 
@@ -83,6 +84,7 @@ export class FieldState<TValue> implements ComposibleValidatable<TValue> {
     // This value vetos all previous values
     this.value = value;
     this.error = undefined;
+    this.hasBeenValidated = false;
     this.$ = value;
     this.on$Reinit();
     this.onUpdate();
@@ -93,7 +95,7 @@ export class FieldState<TValue> implements ComposibleValidatable<TValue> {
   }
 
   @observable validating: boolean = false;
-
+  
   /**
    * Runs validation on the current value immediately
    */
@@ -152,6 +154,10 @@ export class FieldState<TValue> implements ComposibleValidatable<TValue> {
             value
           };
         }
+      }))
+      .then(action(status => {
+        this.hasBeenValidated = true;
+        return status;
       }));
   }
 

--- a/src/tests/fieldState/basic.ts
+++ b/src/tests/fieldState/basic.ts
@@ -14,13 +14,39 @@ describe("FieldState basic", () => {
     assert.equal(name.$, 'hello');
   });
 
+  it("no validation should keep hasBeenValidated false", () => {
+    const name = new FieldState({
+      value: 'hello',
+    })
+    assert.equal(name.hasBeenValidated, false);
+  });
+
+  it("validating changes hasBeenValidated to true", async () => {
+    const name = new FieldState({
+      value: 'hello',
+    })
+    name.onChange('world')
+    await name.validate()    
+    assert.equal(name.hasBeenValidated, true);
+  });
+
+  it("reinitValue changes hasBeenValidated to false", () => {
+    const name = new FieldState({
+      value: 'hello',
+    })
+    name.reinitValue('world')
+    assert.equal(name.hasBeenValidated, false)
+  })
+
   it("reinitValue should change the value immediately", () => {
     const name = new FieldState({
       value: 'hello',
     })
     name.reinitValue('world')
+
     assert.equal(name.value, 'world');
     assert.equal(name.$, 'world');
+    assert.equal(name.hasBeenValidated, false);
   });
 
   it("reinitValue should prevent any automatic validation from running", async () => {
@@ -35,6 +61,7 @@ describe("FieldState basic", () => {
     assert.equal(name.hasError, false);
     assert.equal(name.value, '');
     assert.equal(name.$, '');
+    assert.equal(name.hasBeenValidated, false);
   });
 
   it("reinitValue followed by onChange should run validators", async () => {


### PR DESCRIPTION
This adds the property discussed in #12 
I chose not to change it in onChange to prevent the wanted behavior `unknown -> valid/invalid` to not become `unknown -> valid/invalid -> unknown -> valid/invalid`.
If this behavior is required the property `validating` can be used with this (`name.validating || !name.hasbeenValidated`.

Let me know if you have any comments!