### PR TITLE
Add views for fields/forms

### DIFF
--- a/src/core/ErrorOr.ts
+++ b/src/core/ErrorOr.ts
@@ -1,0 +1,5 @@
+export type ErrorOr<T> = { hasError: true } | { hasError: false, value: T };
+
+export const mapErrorOr = <T1, T2>(res: ErrorOr<T1>, f: (t1: T1) => T2): ErrorOr<T2> =>
+  res.hasError ? res : {hasError: false, value: f(res.value)};
+

--- a/src/core/ViewComposibleValidatable.ts
+++ b/src/core/ViewComposibleValidatable.ts
@@ -6,7 +6,6 @@ export abstract class ViewComposibleValidatable<Wrapped, TValue>
   implements ComposibleValidatable<TValue> {
 
   protected wrapped: ComposibleValidatable<Wrapped>;
-  protected to: (t: Wrapped) => TValue;
 
   constructor(wrapped: ComposibleValidatable<Wrapped>, to: (t: Wrapped) => TValue) {
     super(wrapped, to);

--- a/src/core/ViewComposibleValidatable.ts
+++ b/src/core/ViewComposibleValidatable.ts
@@ -11,7 +11,6 @@ export abstract class ViewComposibleValidatable<Wrapped, TValue>
   constructor(wrapped: ComposibleValidatable<Wrapped>, to: (t: Wrapped) => TValue) {
     super(wrapped, to);
     this.wrapped = wrapped;
-    this.to = to;
   };
 
   on$ChangeAfterValidation() {

--- a/src/core/ViewComposibleValidatable.ts
+++ b/src/core/ViewComposibleValidatable.ts
@@ -1,0 +1,28 @@
+import {ComposibleValidatable} from "./types";
+import {ViewValidatable} from "./ViewValidatable";
+
+export abstract class ViewComposibleValidatable<Wrapped, TValue>
+  extends ViewValidatable<Wrapped, TValue>
+  implements ComposibleValidatable<TValue> {
+
+  protected wrapped: ComposibleValidatable<Wrapped>;
+  protected to: (t: Wrapped) => TValue;
+
+  constructor(wrapped: ComposibleValidatable<Wrapped>, to: (t: Wrapped) => TValue) {
+    super(wrapped, to);
+    this.wrapped = wrapped;
+    this.to = to;
+  };
+
+  on$ChangeAfterValidation() {
+    return this.wrapped.on$ChangeAfterValidation()
+  };
+
+  on$Reinit() {
+    this.wrapped.on$Reinit()
+  }
+
+  setCompositionParent(c: { on$ChangeAfterValidation: () => void; on$Reinit: () => void; }) {
+    return this.wrapped.setCompositionParent(c)
+  };
+}

--- a/src/core/ViewFieldState.ts
+++ b/src/core/ViewFieldState.ts
@@ -7,10 +7,9 @@ export class ViewFieldState<Wrapped, TValue> extends ViewComposibleValidatable<W
   protected wrapped: FieldState<Wrapped>;
   private from: (t: TValue) => Wrapped;
 
-  constructor(wrapped: FieldState<Wrapped>, from: (t: TValue) => Wrapped, to: (t: Wrapped) => TValue) {
+  constructor(wrapped: FieldState<Wrapped>, to: (t: Wrapped) => TValue, from: (t: TValue) => Wrapped) {
     super(wrapped, to);
     this.wrapped = wrapped;
-    this.to = to;
     this.from = from
   };
 
@@ -53,7 +52,7 @@ export class ViewFieldState<Wrapped, TValue> extends ViewComposibleValidatable<W
     this.wrapped.onChange(this.from(value));
 
   onUpdate = (handler: (state: FieldState<TValue>) => any) => {
-    this.wrapped.onUpdate((state: FieldState<Wrapped>) => handler(state.viewedAs<TValue>(this.from, this.to)));
+    this.wrapped.onUpdate((state: FieldState<Wrapped>) => handler(state.viewedAs<TValue>(this.to, this.from)));
     return this;
   };
 
@@ -78,7 +77,7 @@ export class ViewFieldState<Wrapped, TValue> extends ViewComposibleValidatable<W
     return this;
   };
 
-  viewedAs<T>(from: (t: T) => TValue, to: (tValue: TValue) => T): FieldState<T> {
-    return new ViewFieldState<TValue, T>(this, from, to);
+  viewedAs<T>(to: (tValue: TValue) => T, from: (t: T) => TValue): FieldState<T> {
+    return new ViewFieldState<TValue, T>(this, to, from);
   }
 }

--- a/src/core/ViewFieldState.ts
+++ b/src/core/ViewFieldState.ts
@@ -4,6 +4,7 @@ import {ViewComposibleValidatable} from "./ViewComposibleValidatable";
 import {mapErrorOr} from "./ErrorOr";
 
 export class ViewFieldState<Wrapped, TValue> extends ViewComposibleValidatable<Wrapped, TValue> implements FieldState<TValue> {
+
   protected wrapped: FieldState<Wrapped>;
   private from: (t: TValue) => Wrapped;
 

--- a/src/core/ViewFieldState.ts
+++ b/src/core/ViewFieldState.ts
@@ -1,0 +1,84 @@
+import {FieldState} from "./fieldState";
+import {Validator} from "./types";
+import {ViewComposibleValidatable} from "./ViewComposibleValidatable";
+import {mapErrorOr} from "./ErrorOr";
+
+export class ViewFieldState<Wrapped, TValue> extends ViewComposibleValidatable<Wrapped, TValue> implements FieldState<TValue> {
+  protected wrapped: FieldState<Wrapped>;
+  private from: (t: TValue) => Wrapped;
+
+  constructor(wrapped: FieldState<Wrapped>, from: (t: TValue) => Wrapped, to: (t: Wrapped) => TValue) {
+    super(wrapped, to);
+    this.wrapped = wrapped;
+    this.to = to;
+    this.from = from
+  };
+
+  get dirty() {
+    return this.wrapped.dirty;
+  }
+
+  get hasBeenValidated(): boolean {
+    return this.wrapped.hasBeenValidated
+  }
+
+  get value() {
+    return this.to(this.wrapped.value);
+  }
+
+  disableAutoValidation = () => {
+    this.wrapped.disableAutoValidation();
+    return this;
+  };
+
+  enableAutoValidation = () => {
+    this.wrapped.enableAutoValidation();
+    return this
+  };
+
+  enableAutoValidationAndValidate = () =>
+    this.wrapped.enableAutoValidationAndValidate().then(res => mapErrorOr(res, this.to));
+
+  getAutoValidationDefault = () =>
+    this.wrapped.getAutoValidationDefault();
+
+  onDidChange = (handler: (config: { newValue: TValue; oldValue: TValue }) => any) => {
+    this.wrapped.onDidChange(
+      ({newValue, oldValue}) => handler({newValue: this.to(newValue), oldValue: this.to(oldValue)})
+    );
+    return this;
+  };
+
+  onChange = (value: TValue) =>
+    this.wrapped.onChange(this.from(value));
+
+  onUpdate = (handler: (state: FieldState<TValue>) => any) => {
+    this.wrapped.onUpdate((state: FieldState<Wrapped>) => handler(state.viewedAs<TValue>(this.from, this.to)));
+    return this;
+  };
+
+  queuedValidationWakeup = () =>
+    this.wrapped.queuedValidationWakeup();
+
+  reinitValue = (value?: TValue) =>
+    this.wrapped.reinitValue(value && this.from(value));
+
+  setAutoValidationDebouncedMs = (milliseconds: number) => {
+    this.wrapped.setAutoValidationDebouncedMs(milliseconds);
+    return this;
+  };
+
+  setAutoValidationDefault = (v: boolean) => {
+    this.wrapped.setAutoValidationDefault(v);
+    return this;
+  };
+
+  validators = (...vals: Validator<TValue>[]): FieldState<TValue> => {
+    this.wrapped.validators(...vals.map(v => (t: Wrapped) => v(this.to(t))));
+    return this;
+  };
+
+  viewedAs<T>(from: (t: T) => TValue, to: (tValue: TValue) => T): FieldState<T> {
+    return new ViewFieldState<TValue, T>(this, from, to);
+  }
+}

--- a/src/core/ViewFormState.ts
+++ b/src/core/ViewFormState.ts
@@ -1,0 +1,75 @@
+import {ComposibleValidatable, Validator} from "./types";
+import {FormState} from "./formState";
+import {ViewComposibleValidatable} from "./ViewComposibleValidatable";
+import {ErrorOr, mapErrorOr} from "./ErrorOr";
+
+export class ViewFormState<Wrapped, TValue>
+  extends ViewComposibleValidatable<Wrapped, TValue>
+  implements FormState<TValue> {
+
+  protected wrapped: FormState<Wrapped>;
+  private from: (t: TValue) => Wrapped;
+
+  constructor(wrapped: FormState<Wrapped>, from: (t: TValue) => Wrapped, to: (t: Wrapped) => TValue) {
+    super(wrapped, to);
+    this.wrapped = wrapped;
+    this.to = to;
+    this.from = from
+  };
+
+  get fieldError() {
+    return this.wrapped.fieldError;
+  }
+
+  get formError() {
+    return this.wrapped.formError;
+  }
+
+  get hasFieldError() {
+    return this.wrapped.hasFieldError;
+  }
+
+  get hasFormError() {
+    return this.wrapped.hasFormError;
+  }
+
+  get showFormError() {
+    return this.wrapped.showFormError;
+  }
+
+  get validatedSubFields(): ComposibleValidatable<any>[] {
+  return this.wrapped.validatedSubFields;
+}
+
+  clearFormError() {
+    return this.wrapped.clearFormError();
+  }
+
+  compose() {
+    this.wrapped.compose();
+    return this;
+  };
+
+  disableAutoValidation() {
+    this.wrapped.disableAutoValidation();
+    return this;
+  };
+
+  enableAutoValidation = () => {
+    this.wrapped.enableAutoValidation();
+    return this
+  };
+
+  enableAutoValidationAndValidate: () => Promise<ErrorOr<TValue>> =
+    () => this.wrapped.enableAutoValidationAndValidate()
+      .then(res => mapErrorOr(res, this.to));
+
+  validators = (...vals: Validator<TValue>[]): this => {
+    this.wrapped.validators(...vals.map(v => (t: Wrapped) => v(this.to(t))));
+    return this;
+  };
+
+  viewedAs<T>(from: (t: T) => TValue, to: (t: TValue) => T): FormState<T> {
+    return new ViewFormState<TValue, T>(this, from, to);
+  }
+}

--- a/src/core/ViewFormState.ts
+++ b/src/core/ViewFormState.ts
@@ -8,13 +8,11 @@ export class ViewFormState<Wrapped, TValue>
   implements FormState<TValue> {
 
   protected wrapped: FormState<Wrapped>;
-  private from: (t: TValue) => Wrapped;
 
-  constructor(wrapped: FormState<Wrapped>, from: (t: TValue) => Wrapped, to: (t: Wrapped) => TValue) {
+  constructor(wrapped: FormState<Wrapped>, to: (t: Wrapped) => TValue) {
     super(wrapped, to);
     this.wrapped = wrapped;
     this.to = to;
-    this.from = from
   };
 
   get fieldError() {
@@ -69,7 +67,7 @@ export class ViewFormState<Wrapped, TValue>
     return this;
   };
 
-  viewedAs<T>(from: (t: T) => TValue, to: (t: TValue) => T): FormState<T> {
-    return new ViewFormState<TValue, T>(this, from, to);
+  viewedAs<T>(to: (t: TValue) => T): FormState<T> {
+    return new ViewFormState<TValue, T>(this, to);
   }
 }

--- a/src/core/ViewFormStateLazy.ts
+++ b/src/core/ViewFormStateLazy.ts
@@ -4,13 +4,10 @@ import {Validator} from "./types";
 
 export class ViewFormStateLazy<Wrapped, TValue> extends ViewValidatable<Wrapped, TValue> implements FormStateLazy<TValue> {
   protected wrapped: FormStateLazy<Wrapped>;
-  private from: (t: TValue) => Wrapped;
 
-  constructor(wrapped: FormStateLazy<Wrapped>, from: (t: TValue) => Wrapped, to: (t: Wrapped) => TValue) {
+  constructor(wrapped: FormStateLazy<Wrapped>, to: (t: Wrapped) => TValue) {
     super(wrapped, to);
     this.wrapped = wrapped;
-    this.to = to;
-    this.from = from
   };
 
   validators = (...vals: Validator<TValue>[]): FormStateLazy<TValue> => {
@@ -42,7 +39,7 @@ export class ViewFormStateLazy<Wrapped, TValue> extends ViewValidatable<Wrapped,
     return this.wrapped.clearFormError();
   }
 
-  viewedAs<T>(from: (t: T) => TValue, to: (tValue: TValue) => T): FormStateLazy<T> {
-    return new ViewFormStateLazy<TValue, T>(this, from, to);
+  viewedAs<T>(to: (tValue: TValue) => T): FormStateLazy<T> {
+    return new ViewFormStateLazy<TValue, T>(this, to);
   }
 }

--- a/src/core/ViewFormStateLazy.ts
+++ b/src/core/ViewFormStateLazy.ts
@@ -1,0 +1,48 @@
+import {FormStateLazy} from "./formStateLazy";
+import {ViewValidatable} from "./ViewValidatable";
+import {Validator} from "./types";
+
+export class ViewFormStateLazy<Wrapped, TValue> extends ViewValidatable<Wrapped, TValue> implements FormStateLazy<TValue> {
+  protected wrapped: FormStateLazy<Wrapped>;
+  private from: (t: TValue) => Wrapped;
+
+  constructor(wrapped: FormStateLazy<Wrapped>, from: (t: TValue) => Wrapped, to: (t: Wrapped) => TValue) {
+    super(wrapped, to);
+    this.wrapped = wrapped;
+    this.to = to;
+    this.from = from
+  };
+
+  validators = (...vals: Validator<TValue>[]): FormStateLazy<TValue> => {
+    this.wrapped.validators(...vals.map(v => (t: Wrapped) => v(this.to(t))));
+    return this;
+  };
+
+  get fieldError() {
+    return this.wrapped.fieldError;
+  }
+
+  get formError() {
+    return this.wrapped.formError;
+  }
+
+  get hasFieldError() {
+    return this.wrapped.hasFieldError;
+  }
+
+  get hasFormError() {
+    return this.wrapped.hasFormError;
+  }
+
+  get showFormError() {
+    return this.wrapped.showFormError;
+  }
+
+  clearFormError() {
+    return this.wrapped.clearFormError();
+  }
+
+  viewedAs<T>(from: (t: T) => TValue, to: (tValue: TValue) => T): FormStateLazy<T> {
+    return new ViewFormStateLazy<TValue, T>(this, from, to);
+  }
+}

--- a/src/core/ViewFormStateLazy.ts
+++ b/src/core/ViewFormStateLazy.ts
@@ -2,7 +2,10 @@ import {FormStateLazy} from "./formStateLazy";
 import {ViewValidatable} from "./ViewValidatable";
 import {Validator} from "./types";
 
-export class ViewFormStateLazy<Wrapped, TValue> extends ViewValidatable<Wrapped, TValue> implements FormStateLazy<TValue> {
+export class ViewFormStateLazy<Wrapped, TValue>
+  extends ViewValidatable<Wrapped, TValue>
+  implements FormStateLazy<TValue> {
+
   protected wrapped: FormStateLazy<Wrapped>;
 
   constructor(wrapped: FormStateLazy<Wrapped>, to: (t: Wrapped) => TValue) {

--- a/src/core/ViewValidatable.ts
+++ b/src/core/ViewValidatable.ts
@@ -1,0 +1,40 @@
+import {Validatable} from "./types";
+import {ErrorOr, mapErrorOr} from "./ErrorOr";
+
+export abstract class ViewValidatable<Wrapped, TValue>
+  implements Validatable<TValue> {
+
+  protected wrapped: Validatable<Wrapped>;
+  protected to: (t: Wrapped) => TValue;
+
+  constructor(wrapped: Validatable<Wrapped>, to: (t: Wrapped) => TValue) {
+    this.wrapped = wrapped;
+    this.to = to;
+  };
+
+  get error(): string | null | undefined {
+    return this.wrapped.error;
+  }
+
+  get validating() {
+    return this.wrapped.validating
+  };
+
+  get hasError() {
+    return this.wrapped.hasError
+  };
+
+  get $(): TValue {
+    return this.to(this.wrapped.$);
+  }
+
+  enableAutoValidation: () => Validatable<TValue> =
+    () => {
+      this.wrapped.enableAutoValidation();
+      return this;
+    };
+
+  validate(): Promise<ErrorOr<TValue>> {
+    return this.wrapped.validate().then(res => mapErrorOr(res, this.to))
+  }
+}

--- a/src/core/applyValidators.ts
+++ b/src/core/applyValidators.ts
@@ -1,0 +1,45 @@
+import {Validator} from "./types";
+
+/**
+ * Runs the value through a list of validators. As soon as a validation error is detected, the error is returned
+ */
+export function applyValidators<TValue>(value: TValue, validators: Validator<TValue>[]): Promise<string | null | undefined> {
+  return new Promise<string | null | undefined>(resolve => {
+    let currentIndex = 0;
+
+    let gotoNextValidator = () => {
+      currentIndex++;
+      runCurrentValidator();
+    };
+
+    let runCurrentValidator = () => {
+      if (currentIndex == validators.length) {
+        resolve(null);
+        return;
+      }
+      let validator = validators[currentIndex];
+      let res: any = validator(value);
+
+      // no error
+      if (!res) {
+        gotoNextValidator();
+        return;
+      }
+
+      // some error
+      if (!res.then) {
+        resolve(res);
+        return;
+      }
+
+      // wait for error response
+      res.then((msg: any) => {
+        if (!msg) gotoNextValidator();
+        else resolve(msg);
+      })
+    };
+
+    // kickoff
+    runCurrentValidator();
+  });
+}

--- a/src/core/fieldState.ts
+++ b/src/core/fieldState.ts
@@ -27,7 +27,7 @@ export interface FieldState<TValue> extends ComposibleValidatable<TValue> {
   validating: boolean;
   validators: (...validators: Validator<TValue>[]) => FieldState<TValue>;
   value: TValue;
-  viewedAs<T>(from: (t: T) => TValue, to: (tValue: TValue) => T): FieldState<T>
+  viewedAs<T>(to: (tValue: TValue) => T, from: (t: T) => TValue): FieldState<T>
 }
 
 /**
@@ -272,8 +272,8 @@ class FieldStateBase<TValue> implements FieldState<TValue> {
     this.on$Reinit = config.on$Reinit;
   };
 
-  viewedAs<T>(from: (t: T) => TValue, to: (tValue: TValue) => T): FieldState<T> {
-    return new ViewFieldState<TValue, T>(this, from, to);
+  viewedAs<T>(to: (tValue: TValue) => T, from: (t: T) => TValue): FieldState<T> {
+    return new ViewFieldState<TValue, T>(this, to, from);
   }
 }
 

--- a/src/core/formState.ts
+++ b/src/core/formState.ts
@@ -1,5 +1,8 @@
-import { observable, action, computed, runInAction, isObservable, isArrayLike } from 'mobx';
-import { ComposibleValidatable, ErrorOr, Validator, applyValidators } from './types';
+import {action, computed, isArrayLike, isObservable, observable, runInAction} from 'mobx';
+import {ComposibleValidatable, Validator} from './types';
+import {ViewFormState} from "./ViewFormState";
+import {applyValidators} from "./applyValidators";
+import {ErrorOr} from "./ErrorOr";
 
 /** Each key of the object is a validatable */
 export type ValidatableMapOrArray =
@@ -21,12 +24,13 @@ export interface FormState<TValue> extends ComposibleValidatable<TValue> {
   enableAutoValidationAndValidate: () => Promise<ErrorOr<TValue>>;
   validatedSubFields: ComposibleValidatable<any>[];
   validators: (...validators: Validator<TValue>[]) => this;
+  viewedAs<T>(from: (t: T) => TValue, to: (tValue: TValue) => T): FormState<T>;
 }
 
 /**
  * Just a wrapper around the helpers for a set of FieldStates or FormStates
  */
-export class FormStateBase<TValue extends ValidatableMapOrArray> implements FormState<TValue> {
+class FormStateBase<TValue extends ValidatableMapOrArray> implements FormState<TValue> {
   protected mode: 'array' | 'map' = 'map';
   constructor(
     /**
@@ -221,6 +225,10 @@ export class FormStateBase<TValue extends ValidatableMapOrArray> implements Form
   }) => {
     this.on$ChangeAfterValidation = config.on$ChangeAfterValidation;
     this.on$Reinit = config.on$Reinit;
+  }
+
+  viewedAs<T>(from: (t: T) => TValue, to: (tValue: TValue) => T): FormState<T> {
+    return new ViewFormState(this, from, to);
   }
 }
 

--- a/src/core/formState.ts
+++ b/src/core/formState.ts
@@ -24,7 +24,7 @@ export interface FormState<TValue> extends ComposibleValidatable<TValue> {
   enableAutoValidationAndValidate: () => Promise<ErrorOr<TValue>>;
   validatedSubFields: ComposibleValidatable<any>[];
   validators: (...validators: Validator<TValue>[]) => this;
-  viewedAs<T>(from: (t: T) => TValue, to: (tValue: TValue) => T): FormState<T>;
+  viewedAs<T>(to: (tValue: TValue) => T): FormState<T>;
 }
 
 /**
@@ -227,8 +227,8 @@ class FormStateBase<TValue extends ValidatableMapOrArray> implements FormState<T
     this.on$Reinit = config.on$Reinit;
   }
 
-  viewedAs<T>(from: (t: T) => TValue, to: (tValue: TValue) => T): FormState<T> {
-    return new ViewFormState(this, from, to);
+  viewedAs<T>(to: (tValue: TValue) => T): FormState<T> {
+    return new ViewFormState(this, to);
   }
 }
 

--- a/src/core/formState.ts
+++ b/src/core/formState.ts
@@ -1,15 +1,32 @@
 import { observable, action, computed, runInAction, isObservable, isArrayLike } from 'mobx';
-import { ComposibleValidatable, Validator, applyValidators } from './types';
+import { ComposibleValidatable, ErrorOr, Validator, applyValidators } from './types';
 
 /** Each key of the object is a validatable */
 export type ValidatableMapOrArray =
   { [key: string]: ComposibleValidatable<any> }
   | ComposibleValidatable<any>[]
 
+export interface FormState<TValue> extends ComposibleValidatable<TValue> {
+  readonly error: string | null | undefined;
+  readonly fieldError: string | null | undefined;
+  readonly formError: string | null | undefined;
+  readonly hasError: boolean;
+  readonly hasFieldError: boolean;
+  readonly hasFormError: boolean;
+  readonly showFormError: boolean;
+
+  clearFormError(): void;
+  compose(): this;
+  disableAutoValidation: () => void;
+  enableAutoValidationAndValidate: () => Promise<ErrorOr<TValue>>;
+  validatedSubFields: ComposibleValidatable<any>[];
+  validators: (...validators: Validator<TValue>[]) => this;
+}
+
 /**
  * Just a wrapper around the helpers for a set of FieldStates or FormStates
  */
-export class FormState<TValue extends ValidatableMapOrArray> implements ComposibleValidatable<TValue> {
+export class FormStateBase<TValue extends ValidatableMapOrArray> implements FormState<TValue> {
   protected mode: 'array' | 'map' = 'map';
   constructor(
     /**
@@ -45,10 +62,11 @@ export class FormState<TValue extends ValidatableMapOrArray> implements Composib
    * - returns `hasError`
    * - if no error also return the validated values against each key.
    */
-  @action async validate(): Promise<{ hasError: true } | { hasError: false, value: TValue }> {
+  @action async validate(): Promise<ErrorOr<TValue>> {
     this.validating = true;
     const values = this.getValues();
     let fieldsResult = await Promise.all(values.map((value) => value.validate()));
+
     const done = runInAction(() => {
       if (fieldsResult.some(f => f.hasError)) {
         this.validating = false;
@@ -144,6 +162,7 @@ export class FormState<TValue extends ValidatableMapOrArray> implements Composib
   @action public enableAutoValidation = () => {
     this.autoValidationEnabled = true;
     this.getValues().forEach(x => x.enableAutoValidation());
+    return this;
   }
   @action public enableAutoValidationAndValidate = () => {
     this.autoValidationEnabled = true;
@@ -204,3 +223,6 @@ export class FormState<TValue extends ValidatableMapOrArray> implements Composib
     this.on$Reinit = config.on$Reinit;
   }
 }
+
+export const FormState: new<TValue extends ValidatableMapOrArray>($: TValue) => FormState<TValue> =
+  FormStateBase;

--- a/src/core/formStateLazy.ts
+++ b/src/core/formStateLazy.ts
@@ -34,7 +34,7 @@ export interface FormStateLazy<TValue> extends Validatable<TValue> {
    */
   showFormError: boolean;
 
-  viewedAs<T>(from: (t: T) => TValue, to: (tValue: TValue) => T): FormStateLazy<T>
+  viewedAs<T>(to: (tValue: TValue) => T): FormStateLazy<T>
 }
 
 /**
@@ -152,8 +152,8 @@ class FormStateLazyBase<TValue extends ValidatableArray> implements FormStateLaz
     return !this.hasFieldError && this.hasFormError;
   }
 
-  viewedAs<T>(from: (t: T) => TValue, to: (tValue: TValue) => T): FormStateLazy<T> {
-    return new ViewFormStateLazy(this, from, to);
+  viewedAs<T>(to: (tValue: TValue) => T): FormStateLazy<T> {
+    return new ViewFormStateLazy(this, to);
   }
 }
 

--- a/src/core/formStateLazy.ts
+++ b/src/core/formStateLazy.ts
@@ -1,13 +1,60 @@
 import { observable, action, computed, runInAction } from 'mobx';
-import { Validatable, Validator, applyValidators } from './types';
+import { ErrorOr, Validatable, Validator, applyValidators } from './types';
 
 /** Each item in the array is a validatable */
 export type ValidatableArray = Validatable<any>[];
 
+export interface FormStateLazy<TValue extends ValidatableArray> extends Validatable<TValue>{
+  validating: boolean;
+  validators: (...validators: Validator<TValue>[]) => FormStateLazy<TValue>
+  validate: () => Promise<ErrorOr<TValue>>
+  enableAutoValidation: () => FormStateLazy<TValue>
+
+  /**
+   * Does any field or form have an error
+   */
+  hasError: boolean
+
+  /**
+   * Does any field have an error
+   */
+  hasFieldError: boolean
+
+  /**
+   * Does form level validation have an error
+   */
+  hasFormError: boolean
+
+  /**
+   * Call it when you are `reinit`ing child fields
+   */
+  clearFormError: () => void;
+
+  /**
+   * Error from some sub field if any
+   */
+  fieldError: string | null | undefined;
+
+  /**
+   * Error from form if any
+   */
+  formError: string | null | undefined;
+
+  /**
+   * The first error from any sub (if any) or form error
+   */
+  error: string | null | undefined;
+
+  /**
+   * You should only show the form error if there are no field errors
+   */
+  showFormError: boolean;
+}
+
 /**
  * Makes it easier to work with dynamically maintained array
  */
-export class FormStateLazy<TValue extends ValidatableArray> implements Validatable<TValue> {
+class FormStateLazyBase<TValue extends ValidatableArray> implements FormStateLazy<TValue> {
   @computed get $() {
     return this.getFields();
   }
@@ -24,7 +71,7 @@ export class FormStateLazy<TValue extends ValidatableArray> implements Validatab
     return this;
   }
 
-  @action async validate(): Promise<{ hasError: true } | { hasError: false, value: TValue }> {
+  @action async validate(): Promise<ErrorOr<TValue>> {
     this.validating = true;
     const values = this.getFields();
     let fieldsResult = await Promise.all(values.map((value) => value.validate()));
@@ -57,8 +104,8 @@ export class FormStateLazy<TValue extends ValidatableArray> implements Validatab
 
   @action enableAutoValidation = () => {
     this.getFields().forEach(x => x.enableAutoValidation());
+    return this;
   }
-
 
   @observable protected _error: string | null | undefined = '';
 
@@ -119,3 +166,6 @@ export class FormStateLazy<TValue extends ValidatableArray> implements Validatab
     return !this.hasFieldError && this.hasFormError;
   }
 }
+
+export const FormStateLazy: new<TValue extends ValidatableArray>(getFields: () => TValue) => FormStateLazy<TValue> =
+  FormStateLazyBase;

--- a/src/core/formStateLazy.ts
+++ b/src/core/formStateLazy.ts
@@ -1,54 +1,40 @@
-import { observable, action, computed, runInAction } from 'mobx';
-import { ErrorOr, Validatable, Validator, applyValidators } from './types';
+import {action, computed, observable, runInAction} from 'mobx';
+import {Validatable, Validator} from './types';
+import {ViewFormStateLazy} from "./ViewFormStateLazy";
+import {applyValidators} from "./applyValidators";
+import {ErrorOr} from "./ErrorOr";
 
 /** Each item in the array is a validatable */
 export type ValidatableArray = Validatable<any>[];
 
-export interface FormStateLazy<TValue extends ValidatableArray> extends Validatable<TValue>{
-  validating: boolean;
-  validators: (...validators: Validator<TValue>[]) => FormStateLazy<TValue>
-  validate: () => Promise<ErrorOr<TValue>>
-  enableAutoValidation: () => FormStateLazy<TValue>
-
-  /**
-   * Does any field or form have an error
-   */
-  hasError: boolean
-
+export interface FormStateLazy<TValue> extends Validatable<TValue> {
+  validators: (...validators: Validator<TValue>[]) => FormStateLazy<TValue>;
   /**
    * Does any field have an error
    */
-  hasFieldError: boolean
-
+  hasFieldError: boolean;
   /**
    * Does form level validation have an error
    */
-  hasFormError: boolean
-
+  hasFormError: boolean;
   /**
    * Call it when you are `reinit`ing child fields
    */
   clearFormError: () => void;
-
   /**
    * Error from some sub field if any
    */
   fieldError: string | null | undefined;
-
   /**
    * Error from form if any
    */
   formError: string | null | undefined;
-
-  /**
-   * The first error from any sub (if any) or form error
-   */
-  error: string | null | undefined;
-
   /**
    * You should only show the form error if there are no field errors
    */
   showFormError: boolean;
+
+  viewedAs<T>(from: (t: T) => TValue, to: (tValue: TValue) => T): FormStateLazy<T>
 }
 
 /**
@@ -164,6 +150,10 @@ class FormStateLazyBase<TValue extends ValidatableArray> implements FormStateLaz
    */
   @computed get showFormError() {
     return !this.hasFieldError && this.hasFormError;
+  }
+
+  viewedAs<T>(from: (t: T) => TValue, to: (tValue: TValue) => T): FormStateLazy<T> {
+    return new ViewFormStateLazy(this, from, to);
   }
 }
 

--- a/src/core/types.ts
+++ b/src/core/types.ts
@@ -1,5 +1,4 @@
-
-export type ErrorOr<T> = { hasError: true } | { hasError: false, value: T };
+import {ErrorOr} from "./ErrorOr";
 
 /** A truthy string or falsy values */
 export type ValidationResponse =
@@ -15,51 +14,6 @@ export type ValidationResponse =
 export interface Validator<TValue> {
   (value: TValue): ValidationResponse | Promise<ValidationResponse>;
 }
-
-/**
- * Runs the value through a list of validators. As soon as a validation error is detected, the error is returned
- */
-export function applyValidators<TValue>(value: TValue, validators: Validator<TValue>[]): Promise<string | null | undefined> {
-  return new Promise<string | null | undefined>(resolve => {
-    let currentIndex = 0;
-
-    let gotoNextValidator = () => {
-      currentIndex++;
-      runCurrentValidator();
-    }
-
-    let runCurrentValidator = () => {
-      if (currentIndex == validators.length) {
-        resolve(null);
-        return;
-      }
-      let validator = validators[currentIndex];
-      let res: any = validator(value);
-
-      // no error
-      if (!res) {
-        gotoNextValidator();
-        return;
-      }
-
-      // some error
-      if (!res.then) {
-        resolve(res);
-        return;
-      }
-
-      // wait for error response
-      res.then((msg: any) => {
-        if (!msg) gotoNextValidator();
-        else resolve(msg);
-      })
-    }
-
-    // kickoff
-    runCurrentValidator();
-  });
-}
-
 
 /** Anything that provides this interface can be plugged into the validation system */
 export interface Validatable<TValue> {

--- a/src/core/types.ts
+++ b/src/core/types.ts
@@ -1,5 +1,5 @@
-import * as utils from '../internal/utils';
 
+export type ErrorOr<T> = { hasError: true } | { hasError: false, value: T };
 
 /** A truthy string or falsy values */
 export type ValidationResponse =
@@ -64,11 +64,11 @@ export function applyValidators<TValue>(value: TValue, validators: Validator<TVa
 /** Anything that provides this interface can be plugged into the validation system */
 export interface Validatable<TValue> {
   validating: boolean;
-  validate(): Promise<{ hasError: true } | { hasError: false, value: TValue }>;
+  validate(): Promise<ErrorOr<TValue>>;
   hasError: boolean;
   error?: string | null | undefined;
   $: TValue;
-  enableAutoValidation: () => void;
+  enableAutoValidation: () => Validatable<TValue>;
 }
 
 /**

--- a/src/index.ts
+++ b/src/index.ts
@@ -2,3 +2,4 @@ export * from './core/types';
 export * from './core/fieldState';
 export * from './core/formState';
 export * from './core/formStateLazy';
+export {applyValidators} from "./core/applyValidators";

--- a/src/tests/fieldState/views.ts
+++ b/src/tests/fieldState/views.ts
@@ -11,7 +11,7 @@ interface A {
 const A = (str: string) => ({value: str});
 
 const aField: (str: string) => FieldState<A> =
-  str => new FieldState(str).viewedAs<A>(a => a.value, A).viewedAs<string>(A, a => a.value).viewedAs<A>(a => a.value, A);
+  str => new FieldState(str).viewedAs<A>(A, a => a.value).viewedAs<string>(a => a.value, A).viewedAs<A>(A, a => a.value);
 
 
 describe("Views: FieldState basic", () => {

--- a/src/tests/fieldState/views.ts
+++ b/src/tests/fieldState/views.ts
@@ -1,0 +1,159 @@
+import {FieldState} from '../../index';
+import * as assert from 'assert';
+import {delay} from '../utils';
+import {useStrict} from 'mobx';
+
+useStrict(true);
+
+interface A {
+  value: string;
+}
+const A = (str: string) => ({value: str});
+
+const aField: (str: string) => FieldState<A> =
+  str => new FieldState(str).viewedAs<A>(a => a.value, A).viewedAs<string>(A, a => a.value).viewedAs<A>(a => a.value, A);
+
+
+describe("Views: FieldState basic", () => {
+  it("hotValue and safeValue is set to initial value", () => {
+    const name = aField('hello');
+    assert.deepEqual(name.value, A('hello'));
+    assert.deepEqual(name.$, A('hello'));
+    name.on$Reinit()
+  });
+
+  it("no validation should keep hasBeenValidated false", () => {
+    const name = aField('hello');
+    assert.deepEqual(name.hasBeenValidated, false);
+  });
+
+  it("validating changes hasBeenValidated to true", async () => {
+    const name = aField('hello');
+    name.onChange(A('world'));
+    await name.validate();
+    assert.deepEqual(name.hasBeenValidated, true);
+  });
+
+  it("reinitValue changes hasBeenValidated to false", () => {
+    const name = aField('world');
+    name.reinitValue(A('world'));
+    assert.deepEqual(name.hasBeenValidated, false)
+  });
+
+
+  it("reinitValue should change the value immediately", () => {
+    const name = aField('hello');
+    name.reinitValue(A('world'));
+
+    assert.deepEqual(name.value, A('world'));
+    assert.deepEqual(name.$, A('world'));
+    assert.deepEqual(name.hasBeenValidated, false);
+  });
+
+  it("reinitValue should prevent any automatic validation from running", async () => {
+    const name = aField('').validators(
+      (val) => !val.value && 'value required'
+    );
+    name.onChange(A('world'));
+    name.reinitValue(A(''));
+    await delay(300);
+    assert.deepEqual(name.hasError, false);
+    assert.deepEqual(name.value, A(''));
+    assert.deepEqual(name.$, A(''));
+    assert.deepEqual(name.hasBeenValidated, false);
+  });
+
+  it("reinitValue followed by onChange should run validators", async () => {
+    const name = aField('').validators(
+      (val) => !val.value && 'value required'
+    );
+    name.onChange(A('world'));
+    name.reinitValue(A(''));
+    name.onChange(A(''));
+    await delay(300);
+    assert.deepEqual(name.hasError, true);
+    assert.deepEqual(name.value, A(''));
+    assert.deepEqual(name.$, A(''));
+  });
+
+  it("reinitValue followed by validate should still validate", async () => {
+    const name = aField('').validators(
+      (val) => !val.value && 'value required'
+    );
+    name.onChange(A('world'));
+    name.reinitValue(A(''));
+    const res = await name.validate();
+    assert.deepEqual(res.hasError, true);
+    assert.deepEqual(name.value, A(''));
+    assert.deepEqual(name.$, A(''));
+  });
+});
+
+describe('Views: FieldState automatic validation', () => {
+
+  it("If delay is low it should autovalidate fast", async () => {
+    const name = aField('hello').setAutoValidationDebouncedMs(100);
+    name.onChange(A('world'));
+    await delay(300);
+    assert.deepEqual(name.$, A('world'));
+  });
+
+  it("if delay is big it should autovalidate fast", async () => {
+    const name = aField('hello').setAutoValidationDebouncedMs(200);
+    name.onChange(A('world'));
+    await delay(100);
+    assert.deepEqual(name.$, A('hello'));
+  });
+
+  it("default delay value should also work", async () => {
+    const name = aField('hello');
+    name.onChange(A('world'));
+    await delay(100);
+    assert.deepEqual(name.$, A('hello'));
+    await delay(200);
+    assert.deepEqual(name.$, A('world'));
+  });
+});
+
+describe('Views: automatic validation toggling', () => {
+  it("by default its enabled", async () => {
+    const name = aField('hello');
+    name.onChange(A('world'));
+    assert.deepEqual(name.$, A('hello'));
+    await delay(300);
+    assert.deepEqual(name.$, A('world'));
+  });
+
+  it("disabled auto validation should disable", async () => {
+    const name = aField('hello').setAutoValidationDebouncedMs(100).disableAutoValidation();
+    name.onChange(A('world'));
+    assert.deepEqual(name.$, A('hello'));
+    await delay(300);
+    assert.deepEqual(name.$, A('hello'));
+  });
+
+  it("enabled auto validation should enable", async () => {
+    const name = aField('hello').setAutoValidationDebouncedMs(100).enableAutoValidation();
+    name.onChange(A('world'));
+    assert.deepEqual(name.$, A('hello'));
+    await delay(300);
+    assert.deepEqual(name.$, A('world'));
+  });
+});
+
+describe('Views: FieldState onUpdate', () => {
+  it("Should be called if value changes", async () => {
+    let callCount = 0;
+    const name = aField('hello').disableAutoValidation().onUpdate(() => callCount ++);
+    name.onChange(A('world'));
+    await delay(200);
+    assert.deepEqual(callCount, 1);
+  });
+  it("Should be called if automatic validation occurs", async () => {
+    let callCount = 0;
+    const name = aField('hello').setAutoValidationDebouncedMs(100).onUpdate(() => callCount++);
+    name.onChange(A('world'));
+    await delay(200);
+    assert.deepEqual(callCount, 2);
+  });
+});

--- a/src/tests/formState/views.ts
+++ b/src/tests/formState/views.ts
@@ -1,0 +1,227 @@
+import {FieldState, FormState} from '../../index';
+import * as assert from 'assert';
+import {useStrict} from 'mobx';
+import {ValidatableMapOrArray} from "../../core/formState";
+
+useStrict(true);
+
+interface A {
+  value: string;
+}
+const A = (str: string) => ({value: str});
+
+const aField: (str: string) => FieldState<string> =
+  str => new FieldState(str).viewedAs<A>(a => a.value, A).viewedAs<string>(A, a => a.value);
+
+const aForm = <TValue extends ValidatableMapOrArray>(t: TValue) => {
+  let toArray = (tValue: TValue) => [tValue];
+  let fromArray = (array: TValue[]) => array[0];
+  return new FormState(t).viewedAs(fromArray, toArray).viewedAs(toArray, fromArray);
+};
+
+describe("Views:  FormState basic", () => {
+  it("should allow nesting a FieldState", () => {
+    const name = aField('hello');
+    const form = aForm({
+      name,
+    });
+    assert.equal(form.$.name.$, name.$);
+  });
+
+  it("should allow nesting another FormState", () => {
+    const name = aField('hello');
+    const form = aForm({
+      subForm: aForm({
+        name
+      })
+    });
+    assert.equal(form.$.subForm.$.name.$, name.$);
+  });
+
+  it("should allow nesting FieldState and FormState", () => {
+    const name = aField('hello');
+    const username = aField('hello');
+    const password = aField('hello');
+    const form = aForm({
+      name,
+      person: aForm({
+        username,
+        password,
+      })
+    });
+    assert.equal(form.$.name.$, name.$);
+    assert.equal(form.$.person.$.username.$, name.$);
+  });
+
+  it("should allow nesting a FieldState array", () => {
+    const name = aField('hello');
+    const form = aForm([
+      name,
+    ]);
+    assert.equal(form.$[0].$, name.$);
+  });
+
+  it("should allow nesting another FormState array", () => {
+    const name = aField('hello');
+    const form = aForm([
+      aForm([
+        name
+      ])
+    ]);
+    assert.equal(form.$[0].$[0].$, name.$);
+  });
+});
+
+describe("Views:  FormState local validations", () => {
+  it("should validate a local validation", async () => {
+    const name = aField('');
+    const form = aForm({
+      name,
+    }).validators(($) => {
+      return $.name.$.length < 2 && 'The lenght of name must be at least 2';
+    });
+    const res = await form.validate();
+    assert.equal(res.hasError, true);
+    assert.equal(form.hasError, true);
+    assert.equal(form.error, 'The lenght of name must be at least 2');
+  });
+
+  it("array: should validate a local validation", async () => {
+    const name = aField('');
+    const form = aForm([
+      name,
+    ]).validators(($) => {
+      return $.length < 2 && 'You must have at least two names';
+    });
+    const res = await form.validate();
+    assert.equal(res.hasError, true);
+    assert.equal(form.hasError, true);
+    assert.equal(form.error, 'You must have at least two names');
+  });
+})
+
+describe("Views:  FormState validation", () => {
+  it("should validate a nested FieldState and pass if valid", async () => {
+    const name = aField('');
+    const form = aForm({
+      name,
+    });
+    const res = await form.validate();
+    assert.equal(res.hasError, false);
+    assert.equal(form.hasError, false);
+  });
+
+  it("array: should validate a nested FieldState and pass if valid", async () => {
+    const name = aField('');
+    const form = aForm([
+      name,
+    ]);
+    const res = await form.validate();
+    assert.equal(res.hasError, false);
+    assert.equal(form.hasError, false);
+  });
+
+  it("should validate a nested FieldState and fail if invalid", async () => {
+    const name = aField('').validators(
+      (val: string) => !val && 'value required'
+    );
+    const form = aForm({
+      name,
+    });
+    const res = await form.validate();
+
+    assert.equal(res.hasError, true);
+    assert.equal(form.hasError, true);
+    assert.equal(form.error, 'value required');
+    assert.equal(form.$.name.error, 'value required');
+  });
+
+  it("array: should validate a nested FieldState and fail if invalid", async () => {
+    const name = aField('').validators(
+      (val) => !val && 'value required'
+    );
+    const form = aForm([
+      name,
+    ]);
+    const res = await form.validate();
+    assert.equal(res.hasError, true);
+    assert.equal(form.hasError, true);
+    assert.equal(form.error, 'value required');
+    assert.equal(form.$[0].error, 'value required');
+  });
+
+  it("should validate a nested - nested FieldState and pass if valid", async () => {
+    const name = aField('');
+    const form = aForm({
+      name: aForm({
+        name
+      })
+    });
+    const res = await form.validate();
+    assert.equal(res.hasError, false);
+    assert.equal(form.hasError, false);
+  });
+
+  it("array: should validate a nested - nested FieldState and pass if valid", async () => {
+    const name = aField('');
+    const form = aForm([
+      aForm([
+        name
+      ])
+    ]);
+    const res = await form.validate();
+    assert.equal(res.hasError, false);
+    assert.equal(form.hasError, false);
+  });
+
+  it("should validate a nested - nested FieldState and fail if invalid", async () => {
+    const name = aField('').validators(
+      (val) => !val && 'value required'
+    );
+    const form = aForm({
+      name: aForm({
+        name
+      })
+    });
+    const res = await form.validate();
+    assert.equal(res.hasError, true);
+    assert.equal(form.hasError, true);
+    assert.equal(form.error, 'value required');
+    assert.equal(form.$.name.error, 'value required');
+    assert.equal(form.$.name.$.name.$, '');
+  });
+
+  it("array: should validate a nested - nested FieldState and fail if invalid", async () => {
+    const name = aField('').validators(
+      (val) => !val && 'value required'
+    );
+    const form = aForm([
+      aForm([
+        name
+      ])
+    ]);
+    const res = await form.validate();
+    assert.equal(res.hasError, true);
+    assert.equal(form.hasError, true);
+    assert.equal(form.error, 'value required');
+    assert.equal(form.$[0].error, 'value required');
+    assert.equal(form.$[0].$[0].$, '');
+  });
+
+  it("dependent validation should work", async () => {
+    const pass1 = aField('').validators((val) => !val && 'Password required');
+    const pass2 = aField('').validators((val) => val && val !== pass1.$ && 'Passwords must match')
+    const form = aForm({
+      pass1,
+      pass2
+    });
+
+    /** Sample user interaction */
+    form.$.pass1.onChange('hello');
+    form.$.pass2.onChange('he');
+
+    const res = await form.validate();
+    assert.equal(res.hasError, true);
+    assert.equal(pass2.error, 'Passwords must match');
+  });
+});

--- a/src/tests/formState/views.ts
+++ b/src/tests/formState/views.ts
@@ -11,12 +11,12 @@ interface A {
 const A = (str: string) => ({value: str});
 
 const aField: (str: string) => FieldState<string> =
-  str => new FieldState(str).viewedAs<A>(a => a.value, A).viewedAs<string>(A, a => a.value);
+  str => new FieldState(str).viewedAs<A>(A, a => a.value).viewedAs<string>(a => a.value, A);
 
 const aForm = <TValue extends ValidatableMapOrArray>(t: TValue) => {
   let toArray = (tValue: TValue) => [tValue];
   let fromArray = (array: TValue[]) => array[0];
-  return new FormState(t).viewedAs(fromArray, toArray).viewedAs(toArray, fromArray);
+  return new FormState(t).viewedAs(toArray).viewedAs(fromArray);
 };
 
 describe("Views:  FormState basic", () => {

--- a/src/tests/formStateLazy/views.ts
+++ b/src/tests/formStateLazy/views.ts
@@ -1,0 +1,111 @@
+import {FieldState, FormStateLazy} from '../../index';
+import * as assert from 'assert';
+import {useStrict} from 'mobx';
+import {ValidatableArray} from "../../core/formStateLazy";
+
+useStrict(true);
+
+interface A {
+  value: string;
+}
+const A = (str: string) => ({value: str});
+
+const aField: (str: string) => FieldState<string> =
+  str => new FieldState(str).viewedAs<A>(a => a.value, A).viewedAs<string>(A, a => a.value);
+
+const aForm = <TValue extends ValidatableArray>(t: () => TValue) => {
+  let toArray = (tValue: TValue) => [tValue];
+  let fromArray = (array: TValue[]) => array[0];
+  return new FormStateLazy(t).viewedAs(fromArray, toArray).viewedAs(toArray, fromArray);
+};
+
+describe("Views: FormStateLazy basic", () => {
+
+  it("should allow nesting a FieldState array", () => {
+    const name = aField('hello');
+    const form = aForm(() => [
+      name,
+    ]);
+    assert.equal(form.$[0].$, name.$);
+  });
+
+  it("should allow nesting another FormState array", () => {
+    const name = aField('hello');
+    const form = aForm(() => [
+      aForm(() => [
+        name
+      ])
+    ]);
+    assert.equal(form.$[0].$[0].$, name.$);
+  });
+});
+
+describe("Views: FormStateLazy local validations", () => {
+  it("should validate a local validation", async () => {
+    const name = aField('');
+    const form = aForm(()=>[
+      name,
+    ]).validators(($) => {
+      return $.length < 2 && 'You must have at least two names';
+    });
+    const res = await form.validate();
+    assert.equal(res.hasError, true);
+    assert.equal(form.hasError, true);
+    assert.equal(form.error, 'You must have at least two names');
+  });
+})
+
+describe("Views: FormStateLazy validation", () => {
+  it("should validate a nested FieldState and pass if valid", async () => {
+    const name = aField('');
+    const form = aForm(() => [
+      name,
+    ]);
+    const res = await form.validate();
+    assert.equal(res.hasError, false);
+    assert.equal(form.hasError, false);
+  });
+
+  it("should validate a nested FieldState and fail if invalid", async () => {
+    const name = aField('').validators(
+      (val) => !val && 'value required'
+    );
+    const form = aForm(() => [
+      name,
+    ]);
+    const res = await form.validate();
+    assert.equal(res.hasError, true);
+    assert.equal(form.hasError, true);
+    assert.equal(form.error, 'value required');
+    assert.equal(form.$[0].error, 'value required');
+  });
+
+  it("should validate a nested - nested FieldState and pass if valid", async () => {
+    const name = aField('');
+    const form = aForm(() => [
+      aForm(() => [
+        name
+      ])
+    ]);
+    const res = await form.validate();
+    assert.equal(res.hasError, false);
+    assert.equal(form.hasError, false);
+  });
+
+  it("should validate a nested - nested FieldState and fail if invalid", async () => {
+    const name = aField('').validators(
+      (val) => !val && 'value required'
+    );
+    const form = aForm(() => [
+      aForm(() => [
+        name
+      ])
+    ]);
+    const res = await form.validate();
+    assert.equal(res.hasError, true);
+    assert.equal(form.hasError, true);
+    assert.equal(form.error, 'value required');
+    assert.equal(form.$[0].error, 'value required');
+    assert.equal(form.$[0].$[0].$, '');
+  });
+});

--- a/src/tests/formStateLazy/views.ts
+++ b/src/tests/formStateLazy/views.ts
@@ -11,12 +11,12 @@ interface A {
 const A = (str: string) => ({value: str});
 
 const aField: (str: string) => FieldState<string> =
-  str => new FieldState(str).viewedAs<A>(a => a.value, A).viewedAs<string>(A, a => a.value);
+  str => new FieldState(str).viewedAs<A>(A, a => a.value).viewedAs<string>(a => a.value, A);
 
 const aForm = <TValue extends ValidatableArray>(t: () => TValue) => {
   let toArray = (tValue: TValue) => [tValue];
   let fromArray = (array: TValue[]) => array[0];
-  return new FormStateLazy(t).viewedAs(fromArray, toArray).viewedAs(toArray, fromArray);
+  return new FormStateLazy(t).viewedAs(toArray).viewedAs(fromArray);
 };
 
 describe("Views: FormStateLazy basic", () => {

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -14,7 +14,5 @@
       "dom"
     ]
   },
-  "include": [
-    "src/**/*"
-  ]
+  "include": ["src"]
 }


### PR DESCRIPTION
Hey there!

So i just found your library, and we're considering whether it's the right tool for us, given that we just adopted mobx. I'm especially excited about how we can have pretty nicely typed forms.

I have one pain point when using `T` other than `string`, and that is that i sometimes want `T` to change in different contexts. There are other ways to go about this, but if I'm using `FieldState`, say, around the codebase, it's pretty much a given that all my input field react components will take `string` as an input. 

In some parts of the codebase i found it very practical to bundle more information (a label, say) within a `FieldState`, but that is not something that should reach the UI components.

```javascript
const f = new FieldState(true).validators(b => b === false && "must be true")
const ff = f.imap(str => str === "true", b => b ? "true" : "false")

> ff.onChange("true")
undefined
> f.value
true
> ff.onChange("false")
undefined
> f.error
'must be true'
> ff.onChange("true")
undefined
> ff.error
null
```

WDYT? 

Also, the first commit extracts interfaces that i think you will want regardless of this PR, and i'll gladly open a separate PR for it. Since you claim to have a simple library you should definitely prove it by having few operations available! :)
I'm sure with some work we could bring it down to even fewer primitives, but that would be something we could discuss later.