### PR TITLE
Possible mistake in the docs?

### DIFF
--- a/demo/README.md
+++ b/demo/README.md
@@ -278,7 +278,7 @@ form.$.pass2.onChange('he');
 /** What the state will look like after validation */
 const res = await form.validate();
 assert.equal(res.hasError, true);
-assert.equal(pass2.error, 'Passwords must match');
+assert.equal(res.error, 'Passwords must match');
 ```
 
 ## FormStateLazy


### PR DESCRIPTION
 I was reading the docs without ever using the library before and this was not clear to me, why the error message should be attached to the individual field in this case. Is this a mistake?