### PR TITLE
[Tests] Remove focus from the compose test

### DIFF
--- a/src/tests/fieldState/automatic.ts
+++ b/src/tests/fieldState/automatic.ts
@@ -1,7 +1,7 @@
-import { FieldState, FormState } from '../../index';
+import { FieldState } from '../../index';
 import * as assert from 'assert';
 import { delay } from '../utils';
-import { configure , action } from 'mobx';
+import { configure } from 'mobx';
 
 configure({
   enforceActions: true

--- a/src/tests/fieldState/automatic.ts
+++ b/src/tests/fieldState/automatic.ts
@@ -4,7 +4,7 @@ import { delay } from '../utils';
 import { configure } from 'mobx';
 
 configure({
-  enforceActions: true
+  enforceActions: "observed"
 });
 
 describe('FieldState automatic validation', () => {

--- a/src/tests/fieldState/basic.ts
+++ b/src/tests/fieldState/basic.ts
@@ -4,7 +4,7 @@ import { delay } from '../utils';
 import { configure } from "mobx";
 
 configure({
-  enforceActions: true
+  enforceActions: "observed"
 });
 
 describe("FieldState basic", () => {

--- a/src/tests/fieldState/basic.ts
+++ b/src/tests/fieldState/basic.ts
@@ -1,4 +1,4 @@
-import { FieldState, FormState } from '../../index';
+import { FieldState } from '../../index';
 import * as assert from 'assert';
 import { delay } from '../utils';
 import { configure } from "mobx";

--- a/src/tests/fieldState/onUpdate.ts
+++ b/src/tests/fieldState/onUpdate.ts
@@ -4,7 +4,7 @@ import { delay } from '../utils';
 import { configure } from 'mobx';
 
 configure({
-  enforceActions: true
+  enforceActions: "observed"
 });
 
 describe('FieldState onUpdate', () => {

--- a/src/tests/fieldState/onUpdate.ts
+++ b/src/tests/fieldState/onUpdate.ts
@@ -1,4 +1,4 @@
-import { FieldState, FormState } from '../../index';
+import { FieldState } from '../../index';
 import * as assert from 'assert';
 import { delay } from '../utils';
 import { configure } from 'mobx';

--- a/src/tests/formState/basic.ts
+++ b/src/tests/formState/basic.ts
@@ -1,6 +1,5 @@
 import { FieldState, FormState } from '../../index';
 import * as assert from 'assert';
-import { delay } from '../utils';
 import { configure } from 'mobx';
 
 configure({

--- a/src/tests/formState/basic.ts
+++ b/src/tests/formState/basic.ts
@@ -3,7 +3,7 @@ import * as assert from 'assert';
 import { configure } from 'mobx';
 
 configure({
-  enforceActions: true
+  enforceActions: "observed"
 });
 
 describe("FormState basic", () => {

--- a/src/tests/formState/compose.ts
+++ b/src/tests/formState/compose.ts
@@ -4,7 +4,7 @@ import { delay } from '../utils';
 import { configure } from 'mobx';
 
 configure({
-  enforceActions: true
+  enforceActions: "observed"
 });
 
 describe("FormState validation", () => {

--- a/src/tests/formState/compose.ts
+++ b/src/tests/formState/compose.ts
@@ -27,7 +27,7 @@ describe("FormState validation", () => {
     form.validate();
   });
 
-  it.only("Should start running form validators as soon as all fields have been validated", async () => {
+  it("Should start running form validators as soon as all fields have been validated", async () => {
     const required = (val: string) => !val && "Required";
     const form = new FormState({
       pass1: new FieldState("").validators(required),

--- a/src/tests/formState/localValidations.ts
+++ b/src/tests/formState/localValidations.ts
@@ -1,6 +1,5 @@
 import { FieldState, FormState } from '../../index';
 import * as assert from 'assert';
-import { delay } from '../utils';
 import { configure } from 'mobx';
 
 configure({

--- a/src/tests/formState/localValidations.ts
+++ b/src/tests/formState/localValidations.ts
@@ -3,7 +3,7 @@ import * as assert from 'assert';
 import { configure } from 'mobx';
 
 configure({
-  enforceActions: true
+  enforceActions: "observed"
 });
 
 describe("FormState local validations", () => {

--- a/src/tests/formState/validation.ts
+++ b/src/tests/formState/validation.ts
@@ -1,6 +1,5 @@
 import { FieldState, FormState } from '../../index';
 import * as assert from 'assert';
-import { delay } from '../utils';
 import { configure } from 'mobx';
 
 configure({

--- a/src/tests/formState/validation.ts
+++ b/src/tests/formState/validation.ts
@@ -3,7 +3,7 @@ import * as assert from 'assert';
 import { configure } from 'mobx';
 
 configure({
-  enforceActions: true
+  enforceActions: "observed"
 });
 
 describe("FormState validation", () => {

--- a/src/tests/formStateLazy/basic.ts
+++ b/src/tests/formStateLazy/basic.ts
@@ -1,6 +1,5 @@
 import { FieldState, FormState, FormStateLazy } from '../../index';
 import * as assert from 'assert';
-import { delay } from '../utils';
 import { configure } from 'mobx';
 
 configure({

--- a/src/tests/formStateLazy/basic.ts
+++ b/src/tests/formStateLazy/basic.ts
@@ -3,7 +3,7 @@ import * as assert from 'assert';
 import { configure } from 'mobx';
 
 configure({
-  enforceActions: true
+  enforceActions: "observed"
 });
 
 describe("FormStateLazy basic", () => {

--- a/src/tests/formStateLazy/localValidations.ts
+++ b/src/tests/formStateLazy/localValidations.ts
@@ -1,6 +1,5 @@
 import { FieldState, FormStateLazy } from '../../index';
 import * as assert from 'assert';
-import { delay } from '../utils';
 import { configure } from 'mobx';
 
 configure({

--- a/src/tests/formStateLazy/localValidations.ts
+++ b/src/tests/formStateLazy/localValidations.ts
@@ -3,7 +3,7 @@ import * as assert from 'assert';
 import { configure } from 'mobx';
 
 configure({
-  enforceActions: true
+  enforceActions: "observed"
 });
 
 describe("FormStateLazy local validations", () => {

--- a/src/tests/formStateLazy/validation.ts
+++ b/src/tests/formStateLazy/validation.ts
@@ -1,6 +1,5 @@
-import { FieldState, FormState, FormStateLazy } from '../../index';
+import { FieldState, FormStateLazy } from '../../index';
 import * as assert from 'assert';
-import { delay } from '../utils';
 import { configure } from 'mobx';
 
 configure({

--- a/src/tests/formStateLazy/validation.ts
+++ b/src/tests/formStateLazy/validation.ts
@@ -3,7 +3,7 @@ import * as assert from 'assert';
 import { configure } from 'mobx';
 
 configure({
-  enforceActions: true
+  enforceActions: "observed"
 });
 
 describe("FormStateLazy validation", () => {


### PR DESCRIPTION
Hi Basarat. 

Thanks for this great library. Like the tagline claimed, I have fallen in love with this library 😍

I recently upgraded to `1.3.0` and while reviewing the diff, I noticed a `.only` on the compose test.

While updating the tests, I took the liberty of removing unused imports within the tests.

Running the tests revealed the following deprecation:
> [mobx] Deprecated: Deprecated value for 'enforceActions', use 'false' => '"never"', 'true' => '"observed"', '"strict"' => "'always'" instead

I have committed these as separate commits so I can remove any changes that are not desired. 

Let me know if these changes are acceptable or if there are any further desired changes.