### PR TITLE
Add getRawValues functionality

### DIFF
--- a/src/core/fieldState.ts
+++ b/src/core/fieldState.ts
@@ -1,4 +1,4 @@
-import { observable, action, computed, runInAction } from 'mobx';
+import { observable, action, computed, runInAction, isObservableArray } from 'mobx';
 import { ComposibleValidatable, Validator, applyValidators } from './types';
 import { debounce } from '../internal/utils';
 
@@ -136,6 +136,14 @@ export class FieldState<TValue> implements ComposibleValidatable<TValue> {
     this.executeOnUpdate();
     if (this._autoValidationEnabled) {
       this.queueValidation();
+    }
+  }
+
+  getRawValues(): TValue {
+    if (isObservableArray(this.value)) {
+      return (this.value as any).map((v: ComposibleValidatable<any>) => v.getRawValues());
+    } else {
+      return this.value;
     }
   }
 

--- a/src/core/fieldState.ts
+++ b/src/core/fieldState.ts
@@ -194,7 +194,7 @@ export class FieldState<TValue> implements ComposibleValidatable<TValue> {
           else {
             return {
               hasError: false as false,
-              value: this.$,
+              value: this.getRawValues(),
             };
           }
         }

--- a/src/core/formState.ts
+++ b/src/core/formState.ts
@@ -9,6 +9,8 @@ export type RecursiveValues<X> = X extends FormState<infer InnerForm>
   ? FieldType
   : never;
 
+type ValidatedRecursiveValues<X> = { hasError: true} | {hasError: false, value: RecursiveValues<X>}
+
 /** Each key of the object is a validatable */
 export type ValidatableMapOrArray =
   /** Mode: object */
@@ -83,7 +85,7 @@ export class FormState<TValue extends ValidatableMapOrArray> implements Composib
    * - returns `hasError`
    * - if no error also return the validated values against each key.
    */
-  @action async validate(): Promise<{ hasError: true } | { hasError: false, value: TValue }> {
+  @action async validate(): Promise<ValidatedRecursiveValues<this>> {
     this.validating = true;
     const values = this.getValues();
     let fieldsResult = await Promise.all(values.map((value) => value.validate()));
@@ -110,7 +112,7 @@ export class FormState<TValue extends ValidatableMapOrArray> implements Composib
       }
 
       this._on$ValidationPass();
-      return { hasError: false as false, value: this.$ };
+      return { hasError: false as false, value: this.getRawValues() };
     });
 
     return res;

--- a/src/core/types.ts
+++ b/src/core/types.ts
@@ -72,7 +72,7 @@ export function applyValidators<TValue>(value: TValue, validators: Validator<TVa
 /** Anything that provides this interface can be plugged into the validation system */
 export interface Validatable<TValue> {
   validating: boolean;
-  validate(): Promise<{ hasError: true } | { hasError: false, value: TValue }>;
+  validate(): Promise<{ hasError: true } | { hasError: false, value: unknown }>;
   hasError: boolean;
   error?: string | null | undefined;
   $: TValue;

--- a/src/core/types.ts
+++ b/src/core/types.ts
@@ -86,6 +86,7 @@ export interface Validatable<TValue> {
 export interface ComposibleValidatable<TValue> extends Validatable<TValue> {
   /** Allows a convinient reset for all fields */
   reset: () => void;
+  getRawValues: () => unknown;
 
   /** Used to tell the parent about validation */
   _on$ValidationPass: () => void;

--- a/src/tests/formState/validation.ts
+++ b/src/tests/formState/validation.ts
@@ -12,8 +12,14 @@ describe("FormState validation", () => {
     const form = new FormState({
       name,
     });
+
+    form.$.name.onChange('hello');
+
     const res = await form.validate();
     assert.equal(res.hasError, false);
+    if (!res.hasError) { // always true because the its checked by the previous assert
+      assert.equal(res.value.name, 'hello');
+    }
     assert.equal(form.hasError, false);
   });
 
@@ -22,8 +28,14 @@ describe("FormState validation", () => {
     const form = new FormState([
       name,
     ]);
-    const res = await form.validate();
+
+    form.$[0].onChange('hello')
+
+    const res = await form.validate(); 
     assert.equal(res.hasError, false);
+    if (!res.hasError) { // always true because the its checked by the previous assert
+      assert.deepEqual(res.value, ['hello']);
+    }
     assert.equal(form.hasError, false);
   });
 
@@ -33,6 +45,9 @@ describe("FormState validation", () => {
       new Map([["hello", name]])
     );
     const res = await form.validate();
+    if (!res.hasError) { // always true because the its checked by the previous assert
+      assert.strictEqual(res.value['hello'], '');
+    }
     assert.equal(res.hasError, false);
     assert.equal(form.hasError, false);
   });


### PR DESCRIPTION
As discussed in https://github.com/formstate/formstate/issues/69, this PR adds a function in `formState` and `fieldState` classes to get their raw, unobserved values. The function implementation uses `any`, but the external API is entirely type-safe.

@basarat, if you approve of the functionality, I'll add tests and documentation.