### PR TITLE
The last MobX get rid of isArrayLike method

### DIFF
--- a/src/core/formState.ts
+++ b/src/core/formState.ts
@@ -1,6 +1,10 @@
-import { action, computed, isArrayLike, isObservable, observable, runInAction } from 'mobx';
+import { action, computed,  isObservable, isObservableArray, IObservableArray, observable, runInAction } from 'mobx';
 import { isMapLike } from "../internal/utils";
 import { applyValidators, ComposibleValidatable, Validator } from './types';
+
+function isArrayLike(x: any): x is any[] | IObservableArray {
+  return Array.isArray(x) || isObservableArray(x);
+}
 
 /** Each key of the object is a validatable */
 export type ValidatableMapOrArray =


### PR DESCRIPTION
https://github.com/mobxjs/mobx/blob/mobx6/CHANGELOG.md#changes-that-might-affect-you
> - `isArrayLike` is no longer exposed as utility. Use `Array.isArray(x) || isObservableArray(x)` instead.