### PR TITLE
Adjust to MobX 6+

### DIFF
--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
   },
   "homepage": "https://github.com/formstate/formstate#readme",
   "peerDependencies": {
-    "mobx": ">=3.0.0"
+    "mobx": ">=6.0.0"
   },
   "dependencies": {},
   "devDependencies": {
@@ -47,15 +47,15 @@
     "eze": "0.12.0",
     "fs-extra": "8.1.0",
     "gh-pages": "2.1.1",
-    "mobx": "5.13.0",
-    "mobx-react": "6.1.3",
+    "mobx": "6.0.1",
+    "mobx-react": "7.0.0",
     "mocha": "6.2.0",
     "moment": "2.24.0",
     "react": "16.9.0",
     "react-dom": "16.9.0",
     "starts": "0.8.0",
     "ts-node": "8.3.0",
-    "typescript": "3.6.2",
+    "typescript": "4.0.3",
     "typestyle": "2.0.4"
   }
 }

--- a/src/scripts/demos/06 cars.tsx
+++ b/src/scripts/demos/06 cars.tsx
@@ -2,7 +2,7 @@
 import * as React from 'react';
 import { render, Button, ErrorText, vertical } from './mui';
 import { observer } from 'mobx-react';
-import { observable, action } from 'mobx';
+import { observable, action, makeObservable } from 'mobx';
 import { resize } from 'eze/lib/client';
 import { Vertical, Horizontal } from './gls';
 
@@ -32,9 +32,9 @@ type Car = FormState<{ name: Name, features: Features }>;
 type Cars = FormState<Car[]>;
 
 class AppState {
-  @observable cars: Cars = new FormState([]).validators(atLeastOneWithMessage("At least on car is needed"));
+  cars: Cars = new FormState([]).validators(atLeastOneWithMessage("At least on car is needed"));
 
-  @action addACar = () => {
+  addACar = () => {
     const car: Car = new FormState({
       name: new FieldState('').validators(requiredWithMessage("Car needs a name")),
       features: new FormState([]).validators(atLeastOneWithMessage("Car must have at least one feature")),
@@ -42,13 +42,21 @@ class AppState {
     this.cars.$.push(car);
   }
 
-  @action addAFeatureToACar = (car: Car) => {
+  addAFeatureToACar = (car: Car) => {
     const feature: Feature
       = new FormState({
         name: new FieldState('')
           .validators(requiredWithMessage("Feature needs a name"))
       });
     car.$.features.$.push(feature);
+  }
+
+  constructor() {
+    makeObservable(this, {
+      cars: observable,
+      addACar: action,
+      addAFeatureToACar: action
+    });
   }
 }
 const state = new AppState();

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -6,7 +6,7 @@
     "moduleResolution": "node",
     "esModuleInterop": true,
     "outDir": "./lib",
-    "experimentalDecorators": true,
+    "useDefineForClassFields": true,
     "noImplicitAny": true,
     "suppressImplicitAnyIndexErrors": true,
     "strictNullChecks": true,


### PR DESCRIPTION
@basarat, MobX provided some other breaking changes in the 6.x, I guess it's time to release `2.0.0`.

MobX changed their attitude towards decorators:
https://mobx.js.org/enabling-decorators.html

And now it's required to enable `useDefineForClassFields`:
https://mobx.js.org/migrating-from-4-or-5.html#getting-started